### PR TITLE
auto-detect if building on an ARM mac or not

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -221,7 +221,7 @@
   <PropertyGroup Condition="'$(IsOSX)' == 'true' and
                             '$(RuntimeIdentifier)' == ''">
     <_UsingDefaultRuntimeIdentifier>true</_UsingDefaultRuntimeIdentifier>
-    <RuntimeIdentifier>osx-x64</RuntimeIdentifier>
+    <RuntimeIdentifier>osx-$(Architecture)</RuntimeIdentifier>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
configured to auto-detect if building on an ARM mac or not

#### Database Migration
NO

#### Description
the windows and linux are able to auto-detect if they are on ARM chips or not.  This change makes MacOS react the same way.

